### PR TITLE
Add LTC Lab logo to header and footer

### DIFF
--- a/src/LTCLabKidsV2.jsx
+++ b/src/LTCLabKidsV2.jsx
@@ -120,9 +120,11 @@ export default function LTCLabKidsV2() {
       <header className="sticky top-0 z-20 border-b border-neutral-200 bg-white/80 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
           <div className="flex items-center gap-3">
-            <div className="grid h-10 w-10 place-items-center rounded-2xl bg-gradient-to-br from-indigo-600 to-fuchsia-600 text-white shadow-sm">
-              <LayoutGrid className="h-5 w-5" />
-            </div>
+            <img
+              src="https://ltclab.edu.az/_next/static/media/lts_logo.29f6d82c.svg"
+              alt="LTC Lab Logo"
+              className="h-10 w-10 rounded-2xl object-contain"
+            />
             <div className="leading-tight">
               <div className="text-sm font-semibold tracking-tight">LTC Lab Kids</div>
               <div className="text-[11px] text-neutral-500">8–14 yaş · 12 aylıq texnologiya səyahəti</div>
@@ -414,8 +416,13 @@ export default function LTCLabKidsV2() {
 
       {/* Footer */}
       <footer className="border-t border-neutral-200 bg-white/70">
-        <div className="mx-auto max-w-6xl px-4 py-6 text-sm text-neutral-600">
-          © {new Date().getFullYear()} LTC Lab Kids · Bakı
+        <div className="mx-auto flex max-w-6xl items-center gap-2 px-4 py-6 text-sm text-neutral-600">
+          <img
+            src="https://ltclab.edu.az/_next/static/media/lts_logo.29f6d82c.svg"
+            alt="LTC Lab Logo"
+            className="h-6 w-6 object-contain"
+          />
+          <span>© {new Date().getFullYear()} LTC Lab Kids · Bakı</span>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- insert LTC Lab logo into site header for consistent branding
- show LTC Lab logo in footer alongside copyright notice

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a01c5231c832da8fc311869c7433a