### PR TITLE
Use LTClab logo in header and footer

### DIFF
--- a/src/LTCLabKidsV2.jsx
+++ b/src/LTCLabKidsV2.jsx
@@ -120,7 +120,7 @@ export default function LTCLabKidsV2() {
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
           <div className="flex items-center gap-3">
             <img
-              src="/Pictures/LTC%20LOGO.png"
+              src="/Pictures/LTClabLOGO.png"
               alt="LTC Lab Kids Logo"
               className="h-10 w-10 rounded-2xl object-contain shadow-sm"
             />
@@ -279,7 +279,7 @@ export default function LTCLabKidsV2() {
             <h3 className="text-lg font-semibold tracking-tight">Öyrənəcəyin texnologiyalar</h3>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-            <ImageLogoChip src="/Pictures/LTC LOGO.png" label="LTC Lab" />
+            <ImageLogoChip src="/Pictures/LTClabLOGO.png" label="LTC Lab" />
             <LogoChip abbr="Sc" label="Scratch" gradient="from-orange-400 to-pink-500" />
             <LogoChip abbr="H5" label="HTML5" gradient="from-orange-500 to-red-500" />
             <LogoChip abbr="CSS" label="CSS3" gradient="from-sky-500 to-blue-600" />
@@ -417,7 +417,7 @@ export default function LTCLabKidsV2() {
       <footer className="border-t border-neutral-200 bg-white/70">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-6 text-sm text-neutral-600">
           <img
-            src="/Pictures/LTC%20LOGO.png"
+            src="/Pictures/LTClabLOGO.png"
             alt="LTC Lab Kids Logo"
             className="h-8 w-8 rounded-2xl object-contain"
           />


### PR DESCRIPTION
## Summary
- Show `public/Pictures/LTClabLOGO.png` in the main navigation bar
- Use the same LTClab logo in the technology stack and footer

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b1be91298832db9ac7dd71b20fdb8