### PR TITLE
Use CSS3 logo in tech section

### DIFF
--- a/src/LTCLabKidsV2.jsx
+++ b/src/LTCLabKidsV2.jsx
@@ -289,7 +289,7 @@ export default function LTCLabKidsV2() {
             <ImageLogoChip src={logoUrl} label="LTC Lab" />
             <LogoChip abbr="Sc" label="Scratch" gradient="from-orange-400 to-pink-500" />
             <LogoChip abbr="H5" label="HTML5" gradient="from-orange-500 to-red-500" />
-            <LogoChip abbr="CSS" label="CSS3" gradient="from-sky-500 to-blue-600" />
+            <ImageLogoChip src="/CSS3_logo.svg" label="CSS3" />
             <LogoChip abbr="JS" label="JavaScript" gradient="from-yellow-400 to-amber-500" />
             <LogoChip abbr="Ar" label="Arduino" gradient="from-emerald-500 to-teal-600" />
             <LogoChip abbr="μB" label="micro:bit" gradient="from-green-500 to-emerald-700" />


### PR DESCRIPTION
## Summary
- display CSS3 with its official logo in technologies list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4059dcf4832db66628157be04422