### PR TITLE
feat: add HTML5 logo to stack section

### DIFF
--- a/src/LTCLabKidsV2.jsx
+++ b/src/LTCLabKidsV2.jsx
@@ -288,7 +288,7 @@ export default function LTCLabKidsV2() {
           <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
             <ImageLogoChip src={logoUrl} label="LTC Lab" />
             <LogoChip abbr="Sc" label="Scratch" gradient="from-orange-400 to-pink-500" />
-            <LogoChip abbr="H5" label="HTML5" gradient="from-orange-500 to-red-500" />
+            <ImageLogoChip src="/html5.png" label="HTML5" />
             <ImageLogoChip src="/CSS3_logo.svg" label="CSS3" />
             <LogoChip abbr="JS" label="JavaScript" gradient="from-yellow-400 to-amber-500" />
             <LogoChip abbr="Ar" label="Arduino" gradient="from-emerald-500 to-teal-600" />


### PR DESCRIPTION
## Summary
- replace HTML5 placeholder chip with real logo image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b46cb4cc4832da07ae34c402835aa