### PR TITLE
feat: add GitHub logo in technologies list

### DIFF
--- a/src/LTCLabKidsV2.jsx
+++ b/src/LTCLabKidsV2.jsx
@@ -294,7 +294,7 @@ export default function LTCLabKidsV2() {
             <ImageLogoChip src="/arduino-1.svg" label="Arduino" />
             <LogoChip abbr="μB" label="micro:bit" gradient="from-green-500 to-emerald-700" />
             <ImageLogoChip src="/0f04f0b2-a39a-4621-8bb5-1f5f7bf9bf10_mq.jpg" label="Teachable Machine" />
-            <LogoChip abbr="GH" label="GitHub" gradient="from-neutral-800 to-neutral-700" />
+            <ImageLogoChip src="/Octicons-mark-github.svg" label="GitHub" />
             <ImageLogoChip src="/openai.svg" label="OpenAI · GenAI" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace GitHub placeholder badge with actual logo using Octicons-mark-github.svg

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c713cb7fc832da2d74dc160bca03e