### PR TITLE
Replace LTC Lab Python label with Python

### DIFF
--- a/src/LTCLabKidsV2.jsx
+++ b/src/LTCLabKidsV2.jsx
@@ -278,7 +278,7 @@ export default function LTCLabKidsV2() {
             <h3 className="text-lg font-semibold tracking-tight">Öyrənəcəyin texnologiyalar</h3>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-            <ImageLogoChip src="/Python-logo-notext.svg.png" label="LTC Lab Python" />
+            <ImageLogoChip src="/Python-logo-notext.svg.png" label="Python" />
             <ImageLogoChip src="/scratch-cat-logo-png_seeklogo-431721.png" label="Scratch" />
             <ImageLogoChip src="/html5.png" label="HTML5" />
             <ImageLogoChip src="/CSS3_logo.svg" label="CSS3" />


### PR DESCRIPTION
## Summary
- update technologies list to show "Python" instead of "LTC Lab Python"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7916d144832dab669ecb082bb4cf